### PR TITLE
Adding support for ActiveMQ.

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -158,6 +158,13 @@
 			<artifactId>geronimo-jms_1.1_spec</artifactId>
 			<version>1.1</version>
 		</dependency>
+
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-client</artifactId>
+            <version>5.8.0</version>
+        </dependency>
+
 		<dependency>
 			<groupId>org.fusesource.stompjms</groupId>
 			<artifactId>stompjms-client</artifactId>

--- a/server/src/main/resources/context/BCSAPI-profile.xml
+++ b/server/src/main/resources/context/BCSAPI-profile.xml
@@ -1,29 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans profile="BCSAPI" 
-	xmlns="http://www.springframework.org/schema/beans"
-	xmlns:jdbc="http://www.springframework.org/schema/jdbc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:context="http://www.springframework.org/schema/context" xmlns:tx="http://www.springframework.org/schema/tx"
-	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+<beans profile="BCSAPI"
+       xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
-    	<bean id="stomp" class="org.fusesource.stomp.jms.StompJmsConnectionFactory">
-	    <property name="username" value="server"/>
-	    <property name="password" value="password"/>
-	    <property name="brokerURI" value="tcp://localhost:61613"/>
-	</bean>
-	
-	<bean id="BCSAPI" class="com.bitsofproof.supernode.core.ImplementBCSAPI" init-method="init" destroy-method="destroy">
-		<constructor-arg>
-			<ref bean="bitcoinNetwork"/>
-		</constructor-arg>
-		<constructor-arg>
-			<ref bean="tx"/>
-		</constructor-arg>
-		<property name="transactionManager" ref="transactionManager" />
-		<property name="connectionFactory" ref="stomp"/>
-	</bean>
-		
+    <beans profile="apollo">
+        <bean id="jmsFactory" class="org.fusesource.stomp.jms.StompJmsConnectionFactory">
+            <property name="username" value="server"/>
+            <property name="password" value="password"/>
+            <property name="brokerURI" value="tcp://localhost:61613"/>
+        </bean>
+    </beans>
+
+    <beans profile="activemq" >
+        <bean id="jmsFactory" class="org.apache.activemq.ActiveMQConnectionFactory"
+              p:userName="sa"
+              p:password="manager"
+              p:brokerURL="tcp://localhost:61616"
+              p:clientID="bitsofproof-supernode-testnet3"/>
+    </beans>
+
+    <beans>
+        <bean id="BCSAPI" class="com.bitsofproof.supernode.core.ImplementBCSAPI" init-method="init"
+              destroy-method="destroy">
+            <constructor-arg>
+                <ref bean="bitcoinNetwork"/>
+            </constructor-arg>
+            <constructor-arg>
+                <ref bean="tx"/>
+            </constructor-arg>
+            <property name="transactionManager" ref="transactionManager"/>
+            <property name="connectionFactory" ref="jmsFactory"/>
+        </bean>
+    </beans>
+
 </beans>


### PR DESCRIPTION
Two new spring configuration profiles added:
- apollo
- activemq

Running the application with the BCSAPI profile will need one of the above profiles:

```
java server/target/bitsofproof-server-1.1-SNAPSHOT.jar testnet3 leveldb BCSAPI activemq
```
